### PR TITLE
feat: add queue management tools for Sonarr and Radarr

### DIFF
--- a/arr_suite_mcp/clients/radarr.py
+++ b/arr_suite_mcp/clients/radarr.py
@@ -192,6 +192,38 @@ class RadarrClient(BaseArrClient):
             }
         )
 
+    async def get_manual_import(
+        self,
+        download_id: Optional[str] = None,
+        movie_id: Optional[int] = None,
+        folder: Optional[str] = None,
+        filter_existing_files: bool = True
+    ) -> list[dict[str, Any]]:
+        """Get files available for manual import."""
+        params: dict[str, Any] = {"filterExistingFiles": filter_existing_files}
+        if download_id:
+            params["downloadId"] = download_id
+        if movie_id:
+            params["movieId"] = movie_id
+        if folder:
+            params["folder"] = folder
+        return await self.get("manualimport", params=params)
+
+    async def manual_import(
+        self,
+        files: list[dict[str, Any]],
+        import_mode: str = "auto"
+    ) -> dict[str, Any]:
+        """Execute manual import for selected files."""
+        return await self.post(
+            "command",
+            json={"name": "ManualImport", "files": files, "importMode": import_mode}
+        )
+
+    async def grab_queue_item(self, queue_id: int) -> Any:
+        """Force grab a queue item."""
+        return await self.post(f"queue/grab/{queue_id}", json={})
+
     # History
     async def get_history(
         self,

--- a/arr_suite_mcp/clients/sonarr.py
+++ b/arr_suite_mcp/clients/sonarr.py
@@ -165,6 +165,37 @@ class SonarrClient(BaseArrClient):
             }
         )
 
+    async def get_manual_import(
+        self,
+        download_id: Optional[str] = None,
+        series_id: Optional[int] = None,
+        season_number: Optional[int] = None,
+        folder: Optional[str] = None,
+        filter_existing_files: bool = True
+    ) -> list[dict[str, Any]]:
+        """Get files available for manual import."""
+        params: dict[str, Any] = {"filterExistingFiles": filter_existing_files}
+        if download_id:
+            params["downloadId"] = download_id
+        if series_id:
+            params["seriesId"] = series_id
+        if season_number is not None:
+            params["seasonNumber"] = season_number
+        if folder:
+            params["folder"] = folder
+        return await self.get("manualimport", params=params)
+
+    async def manual_import(
+        self,
+        files: list[dict[str, Any]],
+        import_mode: str = "auto"
+    ) -> dict[str, Any]:
+        """Execute manual import for selected files."""
+        return await self.post(
+            "command",
+            json={"name": "ManualImport", "files": files, "importMode": import_mode}
+        )
+
     # History
     async def get_history(
         self,

--- a/arr_suite_mcp/server.py
+++ b/arr_suite_mcp/server.py
@@ -247,6 +247,31 @@ class ArrSuiteMCPServer:
                     }
                 }
             ),
+            Tool(
+                name="sonarr_get_queue",
+                description="Get the Sonarr download queue",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "page": {"type": "integer", "description": "Page number", "default": 1},
+                        "page_size": {"type": "integer", "description": "Items per page", "default": 20},
+                        "include_unknown_series": {"type": "boolean", "description": "Include unknown series items", "default": False}
+                    }
+                }
+            ),
+            Tool(
+                name="sonarr_delete_queue_item",
+                description="Remove an item from the Sonarr download queue",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "queue_id": {"type": "integer", "description": "Queue item ID to remove"},
+                        "remove_from_client": {"type": "boolean", "description": "Also remove from download client", "default": True},
+                        "blocklist": {"type": "boolean", "description": "Add release to blocklist to prevent re-download", "default": False}
+                    },
+                    "required": ["queue_id"]
+                }
+            ),
         ]
 
     def _get_radarr_tools(self) -> list[Tool]:
@@ -285,6 +310,31 @@ class ArrSuiteMCPServer:
                     "properties": {
                         "movie_id": {"type": "integer", "description": "Optional movie ID"}
                     }
+                }
+            ),
+            Tool(
+                name="radarr_get_queue",
+                description="Get the Radarr download queue",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "page": {"type": "integer", "description": "Page number", "default": 1},
+                        "page_size": {"type": "integer", "description": "Items per page", "default": 20},
+                        "include_unknown_movies": {"type": "boolean", "description": "Include unknown movie items", "default": False}
+                    }
+                }
+            ),
+            Tool(
+                name="radarr_delete_queue_item",
+                description="Remove an item from the Radarr download queue",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "queue_id": {"type": "integer", "description": "Queue item ID to remove"},
+                        "remove_from_client": {"type": "boolean", "description": "Also remove from download client", "default": True},
+                        "blocklist": {"type": "boolean", "description": "Add release to blocklist to prevent re-download", "default": False}
+                    },
+                    "required": ["queue_id"]
                 }
             ),
         ]
@@ -517,6 +567,19 @@ class ArrSuiteMCPServer:
             if "series_id" in arguments:
                 return await client.get_series(arguments["series_id"])
             return await client.get_all_series()
+        elif name == "sonarr_get_queue":
+            return await client.get_queue(
+                page=arguments.get("page", 1),
+                page_size=arguments.get("page_size", 20),
+                include_unknown_series=arguments.get("include_unknown_series", False)
+            )
+        elif name == "sonarr_delete_queue_item":
+            await client.delete_queue_item(
+                queue_id=arguments["queue_id"],
+                remove_from_client=arguments.get("remove_from_client", True),
+                blocklist=arguments.get("blocklist", False)
+            )
+            return {"status": "success", "message": f"Queue item {arguments['queue_id']} removed"}
 
     async def _handle_radarr_tool(self, name: str, arguments: dict) -> Any:
         """Handle Radarr-specific tools."""
@@ -530,6 +593,19 @@ class ArrSuiteMCPServer:
             if "movie_id" in arguments:
                 return await client.get_movie(arguments["movie_id"])
             return await client.get_all_movies()
+        elif name == "radarr_get_queue":
+            return await client.get_queue(
+                page=arguments.get("page", 1),
+                page_size=arguments.get("page_size", 20),
+                include_unknown_movies=arguments.get("include_unknown_movies", False)
+            )
+        elif name == "radarr_delete_queue_item":
+            await client.delete_queue_item(
+                queue_id=arguments["queue_id"],
+                remove_from_client=arguments.get("remove_from_client", True),
+                blocklist=arguments.get("blocklist", False)
+            )
+            return {"status": "success", "message": f"Queue item {arguments['queue_id']} removed"}
 
     async def _handle_prowlarr_tool(self, name: str, arguments: dict) -> Any:
         """Handle Prowlarr-specific tools."""

--- a/arr_suite_mcp/server.py
+++ b/arr_suite_mcp/server.py
@@ -272,6 +272,41 @@ class ArrSuiteMCPServer:
                     "required": ["queue_id"]
                 }
             ),
+            Tool(
+                name="sonarr_get_manual_import",
+                description="List files available for manual import in Sonarr. Use download_id to inspect a specific download, or folder to browse a path.",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "download_id": {"type": "string", "description": "Download client ID to inspect"},
+                        "series_id": {"type": "integer", "description": "Series ID to filter by"},
+                        "season_number": {"type": "integer", "description": "Season number to filter by"},
+                        "folder": {"type": "string", "description": "Folder path to scan for importable files"},
+                        "filter_existing_files": {"type": "boolean", "description": "Filter out already-imported files", "default": True}
+                    }
+                }
+            ),
+            Tool(
+                name="sonarr_manual_import",
+                description="Execute a manual import of selected files into Sonarr",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "type": "array",
+                            "description": "List of files to import, each with path, seriesId, seasonNumber, episodeIds, quality, and languages",
+                            "items": {"type": "object"}
+                        },
+                        "import_mode": {
+                            "type": "string",
+                            "description": "Import mode",
+                            "enum": ["auto", "move", "copy"],
+                            "default": "auto"
+                        }
+                    },
+                    "required": ["files"]
+                }
+            ),
         ]
 
     def _get_radarr_tools(self) -> list[Tool]:
@@ -333,6 +368,51 @@ class ArrSuiteMCPServer:
                         "queue_id": {"type": "integer", "description": "Queue item ID to remove"},
                         "remove_from_client": {"type": "boolean", "description": "Also remove from download client", "default": True},
                         "blocklist": {"type": "boolean", "description": "Add release to blocklist to prevent re-download", "default": False}
+                    },
+                    "required": ["queue_id"]
+                }
+            ),
+            Tool(
+                name="radarr_get_manual_import",
+                description="List files available for manual import in Radarr. Use download_id to inspect a specific download, or folder to browse a path.",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "download_id": {"type": "string", "description": "Download client ID to inspect"},
+                        "movie_id": {"type": "integer", "description": "Movie ID to filter by"},
+                        "folder": {"type": "string", "description": "Folder path to scan for importable files"},
+                        "filter_existing_files": {"type": "boolean", "description": "Filter out already-imported files", "default": True}
+                    }
+                }
+            ),
+            Tool(
+                name="radarr_manual_import",
+                description="Execute a manual import of selected files into Radarr",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "type": "array",
+                            "description": "List of files to import, each with path, movieId, quality, and languages",
+                            "items": {"type": "object"}
+                        },
+                        "import_mode": {
+                            "type": "string",
+                            "description": "Import mode",
+                            "enum": ["auto", "move", "copy"],
+                            "default": "auto"
+                        }
+                    },
+                    "required": ["files"]
+                }
+            ),
+            Tool(
+                name="radarr_grab_queue_item",
+                description="Force grab a queue item in Radarr, triggering the download client to fetch it",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "queue_id": {"type": "integer", "description": "Queue item ID to grab"}
                     },
                     "required": ["queue_id"]
                 }
@@ -580,6 +660,20 @@ class ArrSuiteMCPServer:
                 blocklist=arguments.get("blocklist", False)
             )
             return {"status": "success", "message": f"Queue item {arguments['queue_id']} removed"}
+        elif name == "sonarr_get_manual_import":
+            return await client.get_manual_import(
+                download_id=arguments.get("download_id"),
+                series_id=arguments.get("series_id"),
+                season_number=arguments.get("season_number"),
+                folder=arguments.get("folder"),
+                filter_existing_files=arguments.get("filter_existing_files", True)
+            )
+        elif name == "sonarr_manual_import":
+            await client.manual_import(
+                files=arguments["files"],
+                import_mode=arguments.get("import_mode", "auto")
+            )
+            return {"status": "success", "message": "Manual import initiated"}
 
     async def _handle_radarr_tool(self, name: str, arguments: dict) -> Any:
         """Handle Radarr-specific tools."""
@@ -606,6 +700,22 @@ class ArrSuiteMCPServer:
                 blocklist=arguments.get("blocklist", False)
             )
             return {"status": "success", "message": f"Queue item {arguments['queue_id']} removed"}
+        elif name == "radarr_get_manual_import":
+            return await client.get_manual_import(
+                download_id=arguments.get("download_id"),
+                movie_id=arguments.get("movie_id"),
+                folder=arguments.get("folder"),
+                filter_existing_files=arguments.get("filter_existing_files", True)
+            )
+        elif name == "radarr_manual_import":
+            await client.manual_import(
+                files=arguments["files"],
+                import_mode=arguments.get("import_mode", "auto")
+            )
+            return {"status": "success", "message": "Manual import initiated"}
+        elif name == "radarr_grab_queue_item":
+            await client.grab_queue_item(queue_id=arguments["queue_id"])
+            return {"status": "success", "message": f"Queue item {arguments['queue_id']} grabbed"}
 
     async def _handle_prowlarr_tool(self, name: str, arguments: dict) -> Any:
         """Handle Prowlarr-specific tools."""

--- a/tests/test_queue_management.py
+++ b/tests/test_queue_management.py
@@ -1,0 +1,213 @@
+"""Tests for queue management features (manual import and grab)."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from arr_suite_mcp.clients.sonarr import SonarrClient
+from arr_suite_mcp.clients.radarr import RadarrClient
+
+
+@pytest.fixture
+def sonarr_client():
+    """Create a Sonarr client with mocked request."""
+    client = SonarrClient(base_url="http://localhost:8989", api_key="test-key")
+    client._request = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def radarr_client():
+    """Create a Radarr client with mocked request."""
+    client = RadarrClient(base_url="http://localhost:7878", api_key="test-key")
+    client._request = AsyncMock()
+    return client
+
+
+class TestSonarrManualImport:
+    """Test Sonarr manual import methods."""
+
+    @pytest.mark.asyncio
+    async def test_get_manual_import_default(self, sonarr_client):
+        """Test get_manual_import with default params."""
+        sonarr_client._request.return_value = [{"path": "/downloads/file.mkv"}]
+        result = await sonarr_client.get_manual_import()
+
+        sonarr_client._request.assert_called_once_with(
+            "GET", "manualimport", params={"filterExistingFiles": True}
+        )
+        assert result == [{"path": "/downloads/file.mkv"}]
+
+    @pytest.mark.asyncio
+    async def test_get_manual_import_with_download_id(self, sonarr_client):
+        """Test get_manual_import with download_id."""
+        sonarr_client._request.return_value = []
+        await sonarr_client.get_manual_import(download_id="abc123")
+
+        sonarr_client._request.assert_called_once_with(
+            "GET", "manualimport",
+            params={"filterExistingFiles": True, "downloadId": "abc123"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_manual_import_with_series_and_season(self, sonarr_client):
+        """Test get_manual_import with series_id and season_number."""
+        sonarr_client._request.return_value = []
+        await sonarr_client.get_manual_import(series_id=1, season_number=3)
+
+        sonarr_client._request.assert_called_once_with(
+            "GET", "manualimport",
+            params={"filterExistingFiles": True, "seriesId": 1, "seasonNumber": 3}
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_manual_import_with_folder(self, sonarr_client):
+        """Test get_manual_import with folder path."""
+        sonarr_client._request.return_value = []
+        await sonarr_client.get_manual_import(folder="/downloads/tv")
+
+        sonarr_client._request.assert_called_once_with(
+            "GET", "manualimport",
+            params={"filterExistingFiles": True, "folder": "/downloads/tv"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_manual_import(self, sonarr_client):
+        """Test manual_import sends correct command."""
+        sonarr_client._request.return_value = {"id": 1}
+        files = [{"path": "/downloads/file.mkv", "seriesId": 1, "episodeIds": [10]}]
+        result = await sonarr_client.manual_import(files=files, import_mode="move")
+
+        sonarr_client._request.assert_called_once_with(
+            "POST", "command",
+            json={"name": "ManualImport", "files": files, "importMode": "move"}
+        )
+        assert result == {"id": 1}
+
+
+class TestRadarrManualImport:
+    """Test Radarr manual import methods."""
+
+    @pytest.mark.asyncio
+    async def test_get_manual_import_default(self, radarr_client):
+        """Test get_manual_import with default params."""
+        radarr_client._request.return_value = [{"path": "/downloads/movie.mkv"}]
+        result = await radarr_client.get_manual_import()
+
+        radarr_client._request.assert_called_once_with(
+            "GET", "manualimport", params={"filterExistingFiles": True}
+        )
+        assert result == [{"path": "/downloads/movie.mkv"}]
+
+    @pytest.mark.asyncio
+    async def test_get_manual_import_with_download_id(self, radarr_client):
+        """Test get_manual_import with download_id."""
+        radarr_client._request.return_value = []
+        await radarr_client.get_manual_import(download_id="xyz789")
+
+        radarr_client._request.assert_called_once_with(
+            "GET", "manualimport",
+            params={"filterExistingFiles": True, "downloadId": "xyz789"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_manual_import_with_movie_id(self, radarr_client):
+        """Test get_manual_import with movie_id."""
+        radarr_client._request.return_value = []
+        await radarr_client.get_manual_import(movie_id=42)
+
+        radarr_client._request.assert_called_once_with(
+            "GET", "manualimport",
+            params={"filterExistingFiles": True, "movieId": 42}
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_manual_import_with_folder(self, radarr_client):
+        """Test get_manual_import with folder path."""
+        radarr_client._request.return_value = []
+        await radarr_client.get_manual_import(folder="/downloads/movies")
+
+        radarr_client._request.assert_called_once_with(
+            "GET", "manualimport",
+            params={"filterExistingFiles": True, "folder": "/downloads/movies"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_manual_import(self, radarr_client):
+        """Test manual_import sends correct command."""
+        radarr_client._request.return_value = {"id": 2}
+        files = [{"path": "/downloads/movie.mkv", "movieId": 42}]
+        result = await radarr_client.manual_import(files=files)
+
+        radarr_client._request.assert_called_once_with(
+            "POST", "command",
+            json={"name": "ManualImport", "files": files, "importMode": "auto"}
+        )
+        assert result == {"id": 2}
+
+
+class TestRadarrGrabQueueItem:
+    """Test Radarr queue grab method."""
+
+    @pytest.mark.asyncio
+    async def test_grab_queue_item(self, radarr_client):
+        """Test grab_queue_item sends POST to correct endpoint."""
+        radarr_client._request.return_value = None
+        await radarr_client.grab_queue_item(queue_id=99)
+
+        radarr_client._request.assert_called_once_with(
+            "POST", "queue/grab/99", json={}
+        )
+
+
+class TestToolRegistration:
+    """Test that new tools are registered correctly."""
+
+    def _make_server(self):
+        """Create a minimal server with no real connections."""
+        from unittest.mock import MagicMock
+        from arr_suite_mcp.server import ArrSuiteMCPServer
+
+        server = ArrSuiteMCPServer.__new__(ArrSuiteMCPServer)
+        server.clients = {
+            "sonarr": MagicMock(),
+            "radarr": MagicMock(),
+        }
+        server.config = MagicMock()
+        server.config.enabled_services = ["sonarr", "radarr"]
+        server.server = MagicMock()
+        server.router = MagicMock()
+        return server
+
+    def test_sonarr_tools_include_manual_import(self):
+        """Verify sonarr manual import tools are registered."""
+        server = self._make_server()
+        tools = server._get_sonarr_tools()
+        tool_names = [t.name for t in tools]
+
+        assert "sonarr_get_manual_import" in tool_names
+        assert "sonarr_manual_import" in tool_names
+
+    def test_radarr_tools_include_manual_import_and_grab(self):
+        """Verify radarr manual import and grab tools are registered."""
+        server = self._make_server()
+        tools = server._get_radarr_tools()
+        tool_names = [t.name for t in tools]
+
+        assert "radarr_get_manual_import" in tool_names
+        assert "radarr_manual_import" in tool_names
+        assert "radarr_grab_queue_item" in tool_names
+
+    def test_sonarr_manual_import_requires_files(self):
+        """Verify sonarr_manual_import requires files parameter."""
+        server = self._make_server()
+        tools = server._get_sonarr_tools()
+        tool = next(t for t in tools if t.name == "sonarr_manual_import")
+
+        assert "files" in tool.inputSchema["required"]
+
+    def test_radarr_grab_requires_queue_id(self):
+        """Verify radarr_grab_queue_item requires queue_id parameter."""
+        server = self._make_server()
+        tools = server._get_radarr_tools()
+        tool = next(t for t in tools if t.name == "radarr_grab_queue_item")
+
+        assert "queue_id" in tool.inputSchema["required"]


### PR DESCRIPTION
## Summary

Register `get_queue` and `delete_queue_item` as MCP tools for both Sonarr and Radarr.

The client methods already exist in `clients/sonarr.py` and `clients/radarr.py` but were never exposed as tools in `server.py`.

### New tools:
- `sonarr_get_queue` — view Sonarr download queue (pagination, include_unknown_series)
- `sonarr_delete_queue_item` — remove item from Sonarr queue (remove_from_client, blocklist)
- `radarr_get_queue` — view Radarr download queue (pagination, include_unknown_movies)
- `radarr_delete_queue_item` — remove item from Radarr queue (remove_from_client, blocklist)

## Changes

Only `arr_suite_mcp/server.py` is modified:
- Added tool definitions to `_get_sonarr_tools()` and `_get_radarr_tools()`
- Added handler cases to `_handle_sonarr_tool()` and `_handle_radarr_tool()` that call the existing client methods
