### PR TITLE
fix(clients): correct Prowlarr v1 + Overseerr /status endpoints

### DIFF
--- a/arr_suite_mcp/clients/overseerr.py
+++ b/arr_suite_mcp/clients/overseerr.py
@@ -292,6 +292,17 @@ class OverseerrClient(BaseArrClient):
         await self.delete(f"settings/sonarr/{server_id}")
 
     # System
+    async def get_system_status(self) -> dict[str, Any]:
+        """Get Overseerr system status.
+
+        Overrides BaseArrClient.get_system_status() because Overseerr
+        exposes status at /api/v1/status, not /api/v1/system/status.
+        Without this override, MCP tools that call
+        client.get_system_status() (e.g. arr_get_system_status) return
+        Overseerr as offline even when the server is healthy.
+        """
+        return await self.get("status")
+
     async def get_status(self) -> dict[str, Any]:
         """Get Overseerr system status."""
         return await self.get("status")

--- a/arr_suite_mcp/clients/prowlarr.py
+++ b/arr_suite_mcp/clients/prowlarr.py
@@ -7,6 +7,11 @@ from .base import BaseArrClient
 class ProwlarrClient(BaseArrClient):
     """Client for interacting with Prowlarr API."""
 
+    def __init__(self, base_url: str, api_key: str, timeout: int = 30, max_retries: int = 3):
+        """Initialize Prowlarr client (uses v1 API)."""
+        super().__init__(base_url, api_key, timeout, max_retries)
+        self._api_version = "v1"  # Prowlarr uses v1, not v3
+
     @property
     def service_name(self) -> str:
         return "Prowlarr"


### PR DESCRIPTION
## Problem

Both `ProwlarrClient` and `OverseerrClient` currently return 404 / `Resource not found at <path>` on every request against a live, healthy upstream server.

### 1. `ProwlarrClient` uses the wrong API version

[`BaseArrClient`](https://github.com/shaktech786/arr-suite-mcp-server/blob/main/arr_suite_mcp/clients/base.py#L56) defaults `_api_version = "v3"`. `ProwlarrClient` doesn't override it, but Prowlarr exposes its API at `/api/v1`, not `/api/v3`. Every URL built by `_build_url()` thus hits a non-existent path.

`OverseerrClient` and `BazarrClient` already correctly override `_api_version` in their `__init__` — this PR just adds the same pattern for Prowlarr.

### 2. `OverseerrClient.get_system_status` hits a non-existent path

The base class's `get_system_status()` calls `/api/v{N}/system/status`. Overseerr exposes status at `/api/v1/status` (no `system/` segment). The existing `get_status()` already targets the right path; this PR adds a `get_system_status()` override so generic MCP tools (e.g. `arr_get_system_status`) stop reporting Overseerr as offline when the server is healthy.

## Confirmed against live services

| Service | Probed | Result |
|---|---|---|
| Prowlarr 2.3.5.5327 | `GET /api/v3/system/status` | 404 |
| Prowlarr 2.3.5.5327 | `GET /api/v1/system/status` (no key) | 401 |
| Prowlarr 2.3.5.5327 | `GET /api/v1/system/status` (with key) | 200 |
| Overseerr 1.34.0 | `GET /api/v1/system/status` | 404 |
| Overseerr 1.34.0 | `GET /api/v1/status` | 200 + version JSON |

## Diff

16-line net addition across the two client files. Pattern mirrors the existing `__init__` override idiom in `OverseerrClient` and `BazarrClient` exactly.

## Real-world impact

I'm running this MCP server packaged via NixOS and have been carrying a local `postPatch` with these two fixes for ~2 days while waiting to upstream them. When merged + tagged, downstream packagers can drop their local patches. Happy to also extend with a unit test if useful — just point me at where you'd want it.

Thanks for the project!